### PR TITLE
🔀 :: (#1) - change logic to observe local

### DIFF
--- a/src/main/kotlin/Macaroni.kt
+++ b/src/main/kotlin/Macaroni.kt
@@ -4,7 +4,7 @@ class Macaroni<T>(
     onRemoteObservable: suspend () -> Flow<T>,
     getLocalData: suspend () -> T,
     onUpdateLocal: suspend (T) -> Unit,
-    onRemoteFailure: (Throwable) -> Unit
+    onRemoteFailure: (Throwable) -> Unit = {}
 ) {
     // remote
     //  'onRemoteObservable' should pass the logic

--- a/src/main/kotlin/MacaroniFlow.kt
+++ b/src/main/kotlin/MacaroniFlow.kt
@@ -1,0 +1,47 @@
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+
+class MacaroniFlow<T> constructor(
+    onRemoteObservable: suspend () -> Flow<T>,
+    onUpdateLocal: suspend (T) -> Unit,
+    onLocalObservable: suspend () -> Flow<T>,
+) {
+
+    private var onRemoteObservable: suspend () -> Flow<T>
+    private var onUpdateLocal: suspend (T) -> Unit
+    private var onLocalObservable: suspend () -> Flow<T>
+
+    init {
+        this.onRemoteObservable = onRemoteObservable
+        this.onUpdateLocal = onUpdateLocal
+        this.onLocalObservable = onLocalObservable
+    }
+
+    suspend fun fetch(onNext: (MacaroniStatus, T) -> Unit) {
+        val localData = onLocalObservable().first()
+        onLocalObservable()
+            .drop(1)
+            .collect { data ->
+                onNext(Success, data)
+            }
+        try {
+            runCatching {
+                onNext(Loading, localData)
+                onRemoteObservable()
+            }.onSuccess {
+                it.collect { data ->
+                    if (localData != data) {
+                        onUpdateLocal(data)
+                    } else {
+                        onNext(Success, data)
+                    }
+                }
+            }.onFailure {
+                onNext(Error, localData)
+            }
+        } catch (e: Exception) {
+            onNext(Error, localData)
+        }
+    }
+}

--- a/src/test/kotlin/MacaroniFlowTest.kt
+++ b/src/test/kotlin/MacaroniFlowTest.kt
@@ -1,0 +1,28 @@
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+
+private suspend fun main() {
+    val macaroni = MacaroniFlow(
+        onRemoteObservable = {
+            flow {
+                delay(100)
+                emit(TestStatus("onRemoteObservable", "test"))
+            }
+        },
+        onUpdateLocal = {
+            delay(100)
+            println("onUpdateLocal")
+        },
+        onLocalObservable = {
+            flow {
+                emit(TestStatus("getLocalData", "first"))
+                delay(200)
+                emit(TestStatus("changeLocal", "nice"))
+            }
+        }
+    )
+
+    macaroni.fetch { status, result ->
+        println("status: $status, result: $result")
+    }
+}


### PR DESCRIPTION
## 💡 개요
Change logic to observe local
* The previous logic generated results based on query results, but we modified the logic to observe local.
This results in fewer parameters when using macaroni.